### PR TITLE
improvements to laser topic

### DIFF
--- a/docs/topics/laser/UsingLaserAndLaserHit.md
+++ b/docs/topics/laser/UsingLaserAndLaserHit.md
@@ -1,0 +1,47 @@
+{@import ../../links.md}
+
+# Using Laser and LaserHit (Java)
+
+The laser system behaves like a raycast: you shoot an invisible line and the engine tells you whether it hit something.
+`Component` methods like `repeat()` run every frame, which makes lasers easy to use in gameplay logic that updates continuously.
+
+## Example (beginner-friendly)
+
+The example below creates a `Laser`, fires it inside `repeat()`, and handles the case where nothing is hit by catching `NoHitException`.
+
+```java
+public class LaserExample extends Component {
+    private final Laser laser = new Laser();
+
+    @Override
+    public void repeat() {
+        try {
+            LaserHit hit = laser.trace(myObject.getGlobalPosition(), myObject.getForward());
+
+            // Use the hit immediately (e.g., read hit point, collider, etc.).
+            // This is where you react to the collision.
+        } catch (NoHitException exception) {
+            // Nothing was hit this frame. Decide what to do here.
+        }
+    }
+}
+```
+
+## Why not store `LaserHit` globally?
+
+For beginners, it may sound convenient to store the `LaserHit` in a global variable and use it later,
+but that is **not a good practice** because the hit data can become outdated after the next frame.
+Lasers are meant to be evaluated **per frame**, so you should use the hit right after you trace.
+
+If you really need to keep it for later, always check if it exists:
+
+```java
+LaserHit cachedHit = null;
+
+// Later...
+if (cachedHit != null) {
+    // Safe to use cachedHit
+}
+```
+
+That `null` check prevents errors when no hit happened and ensures your code stays safe for beginners.

--- a/i18n/pt/docusaurus-plugin-content-docs/current/topics/laser/UsingLaserAndLaserHit.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/topics/laser/UsingLaserAndLaserHit.md
@@ -1,0 +1,47 @@
+{@import ../../links.md}
+
+# Usando Laser e LaserHit (Java)
+
+O sistema de laser se comporta como um raycast: você dispara uma linha invisível e o motor informa se ela atingiu algo.
+Métodos de `Component` como `repeat()` rodam a cada frame, o que torna os lasers fáceis de usar em lógicas de jogo que atualizam continuamente.
+
+## Exemplo (para iniciantes)
+
+O exemplo abaixo cria um `Laser`, dispara dentro de `repeat()` e trata o caso em que nada é atingido capturando `NoHitException`.
+
+```java
+public class LaserExample extends Component {
+    private final Laser laser = new Laser();
+
+    @Override
+    public void repeat() {
+        try {
+            LaserHit hit = laser.trace(myObject.getGlobalPosition(), myObject.getForward());
+
+            // Use o hit imediatamente (ex.: ler ponto de impacto, collider, etc.).
+            // Aqui é onde você reage à colisão.
+        } catch (NoHitException exception) {
+            // Nada foi atingido neste frame. Decida o que fazer aqui.
+        }
+    }
+}
+```
+
+## Por que não armazenar `LaserHit` globalmente?
+
+Para iniciantes, pode parecer conveniente guardar o `LaserHit` em uma variável global e usar depois,
+mas isso **não é uma boa prática** porque os dados do hit podem ficar desatualizados após o próximo frame.
+Lasers devem ser avaliados **por frame**, então você deve usar o hit logo após o trace.
+
+Se você realmente precisar guardar para usar depois, sempre verifique se existe:
+
+```java
+LaserHit cachedHit = null;
+
+// Depois...
+if (cachedHit != null) {
+    // Seguro usar cachedHit
+}
+```
+
+Essa verificação de `null` evita erros quando nenhum hit aconteceu e mantém seu código seguro para iniciantes.


### PR DESCRIPTION
### Motivation
- Remove the Unity/MonoBehaviour comparison from the Laser topic introduction to avoid engine-specific references while keeping the per-frame behavior note about `repeat()`.

### Description
- Edited `docs/topics/laser/UsingLaserAndLaserHit.md` and `i18n/pt/docusaurus-plugin-content-docs/current/topics/laser/UsingLaserAndLaserHit.md` to remove the Unity mention and rephrase the intro so `Component` methods like `repeat()` are described as running every frame.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984029e050483228ab72abd67d16a27)